### PR TITLE
Proposal to correct the issue with Missing tiddler

### DIFF
--- a/$__Aliases.tid
+++ b/$__Aliases.tid
@@ -1,0 +1,80 @@
+created: 20210524134146100
+modified: 20210525083943735
+title: $:/Aliases
+
+This tool makes it easy to add an "aliases" field to tiddlers without aliases, to edit the aliases of these tiddlers or any others that have been modified during the session, as well as to investigate any missing tiddlers.
+
+<!--Adapted from Mat von TWaddle's AliasTids's AliasesOverview tool – http://aliastids.tiddlyspot.com/-->
+
+!! Tiddlers without aliases
+
+<table style="width:100%">
+<tr><th>tiddlers without aliases</th><th></th></tr>
+<tr>
+<td style="padding:0">
+   <$select tiddler='$:/temp/addaliasfield' size='15' class="aliases-select"
+actions="""<$set name=tid value={{$:/temp/addaliasfield}}><$action-setfield $tiddler=<<tid>> $field=aliases $value=""></$set>""">
+   <$list filter='[all[tiddlers]!is[system]!has:field[aliases]!tag[0diary]!tag[foo1]!tag[foo2]sort[]]'>
+      <option><$view field='title'/></option>
+   </$list>
+   </$select>
+</td>
+<td style="text-align:left; vertical-align:top;">
+   Select titles to give them an `aliases` field which<br> makes the tiddler show up in the table below
+</td>
+</tr>
+</table>
+
+(You can manually customize any tags that you want excluded from this table by editing the filter. Simply repeat the `!tag[foo1]!tag[foo2]`… filter with as many tags as you want.)
+
+!! Alias editor
+
+Displayed below are all tiddlers modified during the session that already have an "aliases field", including of course those you will have added an "aliases" field to by clicking on in the table above.
+
+Don't forget the double square brackets in the aliases!
+
+<table class="aliastids-table aliastids-table-fullwidth" style="width:100%" >
+<tr>
+<td style="vertical-align:top; padding:0">
+   <table class="aliastids-table aliastids-table-aliases">
+   <tr><th>tiddler</th><th style="width:100%;">aliases editor</th></tr>
+   <$list filter="[has:field[aliases]!has[draft.of]haschanged[]]">
+   <tr>
+   <td><$link to={{!!title}}><$view field=title/></$link></td>
+   <td style="padding:0"><$edit-text tiddler={{!!title}} field=aliases class="aliastids-editor"/></td>
+   </tr>
+   </$list>
+   </table>
+</td>
+</tr>
+</table>
+
+!! Missing tiddler or alias
+
+<table class="aliastids-table aliastids-table-fullwidth"Aliases overview
+<tr>
+<td style="vertical-align:top; padding:0; width:100%;">
+   <table  class="aliastids-table aliastids-table-missing" style="width:100%">
+      <tr><th>missing</th><th style="width:100%;">appears in</th></tr>
+      <$set name=allaliases filter="[all[tiddlers]get[aliases]]" select=0>
+      <$list filter="[all[missing]sort[title]]-[all[tiddlers]has[aliases]get[aliases]enlist-input[]]" >
+         <tr><td><$link to={{!!title}}><$view field=title/></$link></td>
+         <td>
+         <$list filter="[!is[system]search:text::literal,casesensitive{!!title}!has[draft.of]!aliases{!!title}]" >
+                  <$link to={{!!title}}><$view field=title/> </$link>
+             </$list>
+         </td>
+         </tr>
+      </$list>
+      </$set>
+   </table>
+</td>
+</table>
+
+<style>
+.aliastids-editor {border:0; margin-left:5px; width:95%}
+.aliastids-table {margin:0}
+.aliastids-table-aliases {border-right:1px solid silver;}
+.aliastids-table-missing {border-left:1px solid silver; margin-left:-1px; width:100%; }
+.aliastids-table-fullwidth, .aliases-select {width:100%; border:0;}
+</style>

--- a/$__core_Filters_Missing.tid
+++ b/$__core_Filters_Missing.tid
@@ -4,4 +4,3 @@ filter: [all[missing]sort[title]]-[all[tiddlers]has[aliases]get[aliases]enlist-i
 modified: 20210524123526136
 tags: $:/tags/Filter
 title: $:/core/Filters/Missing
-

--- a/$__core_Filters_Missing.tid
+++ b/$__core_Filters_Missing.tid
@@ -1,0 +1,7 @@
+created: 20210524123520772
+description: {{$:/language/Filters/Missing}}
+filter: [all[missing]sort[title]]-[all[tiddlers]has[aliases]get[aliases]enlist-input[]]
+modified: 20210524123526136
+tags: $:/tags/Filter
+title: $:/core/Filters/Missing
+

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Known limitations:
 How-to:
 * Install from https://mklauber.github.io/tw5-plugins/ or upload files to your Tiddlywiki instance.
 * To add aliases to a tiddler, create an "aliases" field and add as many aliases as you desire. For one single single-word aliases, no brackets are needed. For several aliases, use double square brackets to separate aliases (eg. [[alias1]] [[another alias]] ).
+* Use the [[$:/Aliases]] tool to easily add an "aliases" field to tiddlers without aliases, edit the aliases of these tiddlers or any others that have been modified during the session, as well as to investigate any missing tiddlers.
 
 Change log:
-* 210524: The 'Missing tiddler' tool was populated with aliases, limiting its usefulness. The problem is corrected on versions TiddlyWiki 5.1.23 and above, while behaviour is unchanged on prior versions. The problem is corrected on recent versions of TiddlyWiki by adapting the filter used in [[$:/core/Filters/Missing]] by using the "enlist-input" function, which is available only on TiddlyWiki 5.1.23 and above.
+* 210525: Added an [[$:/Aliases]] tool that makes it easy to add an "aliases" field to tiddlers without aliases, to edit the aliases of these tiddlers or any other that have been modified during the session, as well as to investigate any missing tiddlers.
+* 210524: The 'Missing tiddler' tool was populated with aliases, limiting its usefulness. The problem is corrected on versions TiddlyWiki 5.1.23 and above, while behaviour is unchanged on prior versions. The problem is corrected on recent versions of TiddlyWiki by adapting the filter in [[$:/core/Filters/Missing]] by using the "enlist-input" function, which is available only on TiddlyWiki 5.1.23 and above.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# tiddly-aliases
+JS-based implementation of Wikipedia-style aliases and redirects for non existing tiddlers. This plugin allows you to setup tiddlers with an "aliases" field. All aliases will then also be links to the parent tiddler. This could be useful for situations where you want multiple terms to refer to the same thing, such as when a character has multiple names.
+
+Known limitations:
+* An alias does not re-render automatically when you change the number of aliases it points to. This can make links that look like they're missing actually resolve, and links that look like they resolve instead go to a disambiguation page. However, this issue only lasts until the tiddler holding the link is re-rendered.
+* In TiddlyWiki 5.1.22 and below, the 'Missing tiddler' tool is populated with aliases, limiting its usefulness. This problem is corrected in versions TiddlyWiki 5.1.23 and above using the "enlist-input" function, which is available only on these more recent versions of TiddlyWiki.
+
+How-to:
+* Install from https://mklauber.github.io/tw5-plugins/ or upload files to your Tiddlywiki instance.
+* To add aliases to a tiddler, create an "aliases" field and add as many aliases as you desire. For one single single-word aliases, no brackets are needed. For several aliases, use double square brackets to separate aliases (eg. [[alias1]] [[another alias]] ).
+
+Change log:
+210524: The 'Missing tiddler' tool was populated with aliases, limiting its usefulness. The problem is corrected on versions TiddlyWiki 5.1.23 and above, while behaviour is unchanged on prior versions. The problem is corrected on recent versions of TiddlyWiki by adapting the filter used in [[$:/core/Filters/Missing]] by using the "enlist-input" function, which is available only on TiddlyWiki 5.1.23 and above.

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ How-to:
 * To add aliases to a tiddler, create an "aliases" field and add as many aliases as you desire. For one single single-word aliases, no brackets are needed. For several aliases, use double square brackets to separate aliases (eg. [[alias1]] [[another alias]] ).
 
 Change log:
-210524: The 'Missing tiddler' tool was populated with aliases, limiting its usefulness. The problem is corrected on versions TiddlyWiki 5.1.23 and above, while behaviour is unchanged on prior versions. The problem is corrected on recent versions of TiddlyWiki by adapting the filter used in [[$:/core/Filters/Missing]] by using the "enlist-input" function, which is available only on TiddlyWiki 5.1.23 and above.
+* 210524: The 'Missing tiddler' tool was populated with aliases, limiting its usefulness. The problem is corrected on versions TiddlyWiki 5.1.23 and above, while behaviour is unchanged on prior versions. The problem is corrected on recent versions of TiddlyWiki by adapting the filter used in [[$:/core/Filters/Missing]] by using the "enlist-input" function, which is available only on TiddlyWiki 5.1.23 and above.

--- a/plugin.info
+++ b/plugin.info
@@ -2,8 +2,8 @@
     "title": "$:/plugins/mklauber/aliases",
     "description": "Aliases - Alias Manager",
     "author": "Matthew Lauber",
-    "version": "5.1.22",
-    "core-version": ">=5.1.18",
+    "version": "5.1.23",
+    "core-version": ">=5.1.23",
     "plugin-type": "plugin",
 	"list": "",
     "source": "https://github.com/mklauber/tiddly-aliases"

--- a/plugin.info
+++ b/plugin.info
@@ -3,7 +3,7 @@
     "description": "Aliases - Alias Manager",
     "author": "Matthew Lauber",
     "version": "5.1.23",
-    "core-version": ">=5.1.23",
+    "core-version": ">=5.1.18",
     "plugin-type": "plugin",
 	"list": "",
     "source": "https://github.com/mklauber/tiddly-aliases"


### PR DESCRIPTION
Hi there!

This corrects https://github.com/mklauber/tiddly-aliases/issues/1 & https://github.com/mklauber/tw5-plugins/issues/2.

As a reminder, the 'Missing tiddler' tool was populated with aliases, limiting its usefulness. This workaround adapts the filter used in [[$:/core/Filters/Missing]] by using the "enlist-input" function, which is available only on TiddlyWiki 5.1.23 and above. Behaviour is unchanged on prior versions as the new part of filter is parsed in a non-breaking way when the function doesn't resolve (tested on your current tw5-plugins TiddlyWiki, which is running on 5.1.22).

I also added an extensive Readme file as there was none.

Thanks for your great plugin :)

R²